### PR TITLE
updated .doc server instructions and server script

### DIFF
--- a/source-aspnet/egrants_new/DocPDFConversion/Installation Instructions.txt
+++ b/source-aspnet/egrants_new/DocPDFConversion/Installation Instructions.txt
@@ -1,5 +1,5 @@
 ﻿Installation Instructions
-Micah Hoover, 3/14/2025
+Micah Hoover, 3/14/2025		(updated 3/25/2025 to indicate build server overwrite pitfall, clarification, etc)
 
 This is a complex piece of software that needs to work with our existing eGrants web app.
 In addition to some of the security protocol surprises, anyone facilitating the deployment of this functionality
@@ -28,13 +28,24 @@ Here are the steps to get an environment set up for this :
 
 1) Download Libre Office
 
+	This is what I put in my ticket request :
+
+	Some quick background : we're having trouble converting the old MS Word format .doc to PDF without using an external application, libre office which our web
+	app calls to convert to docx (and later PDF). Please go to : https://www.libreoffice.org/download/download-libreoffice/ To get a latest-ish version of libre
+	office. If you want to pick a different one that should probably work, but we need the .com executable to be in the default location of :
+	C:\Program Files\LibreOffice\program\soffice.com on [environment name] 
+
 2) Confirm Libre Office installation
 
 	It must exist in the file system here :
 
-		C:\Program Files\LibreOffice\program\soffice.exe
+		C:\Program Files\LibreOffice\program\soffice.com
 
 3) Deploy a branch of the eGrants app on Jenkins to the desired environment (if you're deploying to an upper tier environment, this should be in main or a build number branch to be provided)
+
+	Note : if a subsequent build on the build server does not have these changes (anything output in DocPDFConversion, this directory), they will be overwritten.
+
+	So make sure the build you want is the most recent build before deploying.
 
 4) Run one of the set up scripts in this directory with the corresponding environment name appended to the script name (e.g. createServerSchedTaskStage.ps1).
 

--- a/source-aspnet/egrants_new/DocPDFConversion/serverDocToPdf.ps1
+++ b/source-aspnet/egrants_new/DocPDFConversion/serverDocToPdf.ps1
@@ -2,30 +2,30 @@
 $port = 8081
 
 $baseDir = ""
-# add prod check, unknown at this point
-# D:\NCI Websites\egrants.nci.nih.gov\
-if (Test-Path "D:\" -and "D:\NCI Websites\" -and "C:\Content\egrants.nci.nih.gov" ) {
+Write-Host "Inferring current environment path ..."
+if ((Test-Path -Path "D:\") -and (Test-Path -Path "D:\NCI Websites\") -and (Test-Path -Path "D:\Content\egrants.nci.nih.gov") ) {
     Write-Host "Running from PROD ..."
     $baseDir = "D:\NCI Websites\egrants.nci.nih.gov\DocPDFConversion"
-} else if (Test-Path "D:\" -and "D:\Content"  ) {
+} elseif ((Test-Path -Path "D:\") -and (Test-Path -Path "D:\Content")  ) {
     Write-Host "Running from non - PROD ..."
-    if (Test-Path "D:\Content\egrants.nci.nih.gov\") {
+    if (Test-Path -Path "D:\Content\egrants.nci.nih.gov\") {
         Write-Host "We seem to be running this on QA or Stage ..."
         $baseDir = "D:\Content\egrants.nci.nih.gov\DocPDFConversion"
-    } else if (Test-Path "C:\Content\egrants.nci.nih.gov\DocPDFConversion") {
+    } elseif (Test-Path -Path "C:\Content\egrants.nci.nih.gov\DocPDFConversion") {
         Write-Host "We seem to be running this on dev ..."
         $baseDir = "D:\Content\egrants-web-dev.nci.nih.gov\DocPDFConversion"
     }
-} else if (Test-Path "C:\" -and "C:\Content" -and "C:\Content\egrants.nci.nih.gov") {
+} elseif ((Test-Path -Path "C:\") -and (Test-Path -Path "C:\Content") -and (Test-Path -Path "C:\Content\egrants.nci.nih.gov")) {
     Write-Host "Found an equivalent location on C:/ to run from ..."
     $baseDir = "C:\Content\egrants.nci.nih.gov\DocPDFConversion"
 } else {
     Write-Host "Didn't find any of the shared environment locales, so checking local dev location ..."
-    if (Test-Path "C:\" -and "C:\Users" -and "C:\Users\hooverrl\" -and "C:\Users\hooverrl\Desktop" -and "C:\Users\hooverrl\Desktop\NCI" -and "C:\Users\hooverrl\Desktop\NCI\nciitrc_eGrants") {
+    if ((Test-Path -Path "C:\") -and ("C:\Users") -and (Test-Path -Path "C:\Users\hooverrl\") -and (Test-Path -Path "C:\Users\hooverrl\Desktop") -and (Test-Path -Path "C:\Users\hooverrl\Desktop\NCI") -and (Test-Path -Path "C:\Users\hooverrl\Desktop\NCI\nciitrc_eGrants")) {
         # rather than affirm every point on the way to my personal dev space, just try it ...
          $baseDir = "D:\Content\egrants-web-dev.nci.nih.gov\DocPDFConversion"
     }
 }
+Write-Host "baseDir : $baseDir"
 
 # local dev : "C:\Users\hooverrl\Desktop\NCI\nciitrc_eGrants\source-aspnet\egrants_new\DocPDFConversion"
 # server : "D:\Content\egrants-web-dev.nci.nih.gov\DocPDFConversion"


### PR DESCRIPTION
Updates made to .doc server script and instructions after stage deployment.
**Note :** this can't be (meaningfully) tested in the lower tier environments because they use a different file path

The .ps1 server change reflects syntax changes (that we tried and succeeded with on Stage 3/25/2025).

The instruction update includes the build wipeout discovery we came across earlier in the week.