### PR TITLE
EGrants 1047 - FFR documents not opening

### DIFF
--- a/source-aspnet/eGrants/Controllers/Egrants/EgrantsDocController.cs
+++ b/source-aspnet/eGrants/Controllers/Egrants/EgrantsDocController.cs
@@ -164,39 +164,6 @@ namespace eGrants.Controllers.Egrants
         //}
 
 
-        // show era doc
-        /// <summary>
-        /// The show_era_doc.
-        /// </summary>
-        /// <param name="docurl">
-        /// The docurl.
-        /// </param>
-        /// <returns>
-        /// The <see cref="RedirectResult"/>.
-        /// </returns>
-        //public async Task<RedirectResult> show_era_doc(string docurl)
-        //{
-        //    var certUrl = _configuration["AppSettings:certPath"];
-
-        //    // this value should be kept as a secret 
-        //    var certPass = _configuration["AppSettings:certPass"];
-
-        //    var certificate = new X509Certificate2(certUrl, certPass);
-
-        //    var handler = new HttpClientHandler();
-        //    handler.ClientCertificates.Add(certificate);
-        //    handler.AllowAutoRedirect = false; // same as your current code
-
-        //    using var client = new HttpClient(handler);
-        //    var response = await client.GetAsync(docurl);
-
-        //    response.EnsureSuccessStatusCode();
-
-        //    var tempLink = await response.Content.ReadAsStringAsync();
-
-        //    return Redirect(tempLink);
-        //}
-
         /// <summary>
         /// Show ERA document by retrieving temporary download link
         /// </summary>
@@ -240,7 +207,6 @@ namespace eGrants.Controllers.Egrants
                     var errorContent = await response.Content.ReadAsStringAsync();
                     Log.Error("ERA request failed. Status: {Status}, Content: {Content}",
                         response.StatusCode, errorContent.Substring(0, Math.Min(200, errorContent.Length)));
-                    return StatusCode((int)response.StatusCode, "Failed to retrieve document");
                 }
 
                 var tempLink = await response.Content.ReadAsStringAsync();

--- a/source-aspnet/eGrants/Controllers/Egrants/EgrantsDocController.cs
+++ b/source-aspnet/eGrants/Controllers/Egrants/EgrantsDocController.cs
@@ -91,6 +91,8 @@ using Microsoft.AspNetCore.OutputCaching;
 
 using MsgReader.Outlook;
 
+using Serilog;
+
 namespace eGrants.Controllers.Egrants
 {
     /// <summary>
@@ -172,27 +174,87 @@ namespace eGrants.Controllers.Egrants
         /// <returns>
         /// The <see cref="RedirectResult"/>.
         /// </returns>
-        public async Task<RedirectResult> show_era_doc(string docurl)
+        //public async Task<RedirectResult> show_era_doc(string docurl)
+        //{
+        //    var certUrl = _configuration["AppSettings:certPath"];
+
+        //    // this value should be kept as a secret 
+        //    var certPass = _configuration["AppSettings:certPass"];
+
+        //    var certificate = new X509Certificate2(certUrl, certPass);
+
+        //    var handler = new HttpClientHandler();
+        //    handler.ClientCertificates.Add(certificate);
+        //    handler.AllowAutoRedirect = false; // same as your current code
+
+        //    using var client = new HttpClient(handler);
+        //    var response = await client.GetAsync(docurl);
+
+        //    response.EnsureSuccessStatusCode();
+
+        //    var tempLink = await response.Content.ReadAsStringAsync();
+
+        //    return Redirect(tempLink);
+        //}
+
+        /// <summary>
+        /// Show ERA document by retrieving temporary download link
+        /// </summary>
+        /// <param name="docurl">The document URL</param>
+        /// <returns>Redirect to temporary download link or error view</returns>
+        public async Task<IActionResult> show_era_doc(string docurl)
         {
-            var certUrl = _configuration["AppSettings:certPath"];
+            try
+            {
 
-            // this value should be kept as a secret 
-            var certPass = _configuration["AppSettings:certPass"];
+                var certUrl = _configuration["AppSettings:certPath"];
+                var certPass = _configuration["AppSettings:certPass"];
 
-            var certificate = new X509Certificate2(certUrl, certPass);
+                if (string.IsNullOrEmpty(certUrl) || !System.IO.File.Exists(certUrl))
+                {
+                    Log.Error("Certificate not found at path: {CertPath}", certUrl);
+                }
 
-            var handler = new HttpClientHandler();
-            handler.ClientCertificates.Add(certificate);
-            handler.AllowAutoRedirect = false; // same as your current code
+                var certificate = new X509Certificate2(certUrl, certPass);
 
-            using var client = new HttpClient(handler);
-            var response = await client.GetAsync(docurl);
+                var handler = new HttpClientHandler
+                {
+                    AllowAutoRedirect = false, // Prevent automatic redirects
+                    ClientCertificateOptions = ClientCertificateOption.Manual
+                };
+                handler.ClientCertificates.Add(certificate);
 
-            response.EnsureSuccessStatusCode();
+                using var client = new HttpClient(handler);
+                client.DefaultRequestHeaders.Add("User-Agent", "eGrants");
+                client.Timeout = TimeSpan.FromSeconds(30);
 
-            var tempLink = await response.Content.ReadAsStringAsync();
+                Log.Information("Requesting ERA document: {DocUrl}", docurl);
 
-            return Redirect(tempLink);
+                var response = await client.GetAsync(docurl);
+
+                // Log response details
+                Log.Information("ERA response status: {StatusCode}", response.StatusCode);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    var errorContent = await response.Content.ReadAsStringAsync();
+                    Log.Error("ERA request failed. Status: {Status}, Content: {Content}",
+                        response.StatusCode, errorContent.Substring(0, Math.Min(200, errorContent.Length)));
+                    return StatusCode((int)response.StatusCode, "Failed to retrieve document");
+                }
+
+                var tempLink = await response.Content.ReadAsStringAsync();
+                tempLink = tempLink?.Trim();
+
+                Log.Information("Redirecting to temporary link: {TempLink}", tempLink);
+
+                return Redirect(tempLink);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Unexpected error in show_era_doc for URL: {DocUrl}", docurl);
+                throw;
+            }
         }
 
 


### PR DESCRIPTION
I am creating this PR since Alena was having issues opening FFR documents on test. After adding this logging I found out that the appsettings was pointing to the wrong cert, so the code was potentially okay. However I think it would be ideal to have this logging and these checks in place for code handled with certificates. This code was tested on test environment and it works as expected.