### PR TITLE
Missing transformation for test cert path

### DIFF
--- a/source-aspnet/eGrants/appsettings.Test.json
+++ b/source-aspnet/eGrants/appsettings.Test.json
@@ -8,6 +8,7 @@
     "eraUrlBase": "https://services.internal.era.nih.gov/",
     "closeoutAcceptance": "https://apps.test.era.nih.gov/pgm/jsp/closeoutAcceptance.jsp",
     "frpprAcceptance": "https://apps.test.era.nih.gov/pmm/fpr.era",
-    "irpprAcceptance": "https://apps.test.era.nih.gov/pmm/interimRPPRs.era"
+    "irpprAcceptance": "https://apps.test.era.nih.gov/pmm/interimRPPRs.era",
+    "certPath": "C:\\utils\\cert\\2025\\EGRANTS-WEB-TEST_NCI_NIH_GOV.pfx"
   }
 }


### PR DESCRIPTION
The missing transformation is causing the test app to point to the dev cert, but it is supposed to point to the test cert. This change should fix that.