### PR TITLE
Merge from Dev to Test branch

### DIFF
--- a/source-aspnet/eGrants/Views/eGrants/_egrants_showDocsDownload.cshtml
+++ b/source-aspnet/eGrants/Views/eGrants/_egrants_showDocsDownload.cshtml
@@ -123,17 +123,23 @@ This view sends the same request format but benefits from faster server processi
     table.dataTable tbody tr.even-row { background-color: #ffffff; height: 30px; }
     table.dataTable tbody tr.odd-row { background-color: #AED6F1; height: 30px; }
 
-    #overlay {
-        background-color: white;
+    /* Fix link visibility on all rows - ensure links are readable on hover */
+    table.dataTable tbody a { color: darkblue; }
+    table.dataTable tbody a:link { color: darkblue; }
+    table.dataTable tbody a:visited { color: darkblue; }
+    table.dataTable tbody a:hover { color: black; text-decoration: underline; }
+
+ #overlay {
+      background-color: white;
         display: none;
         height: 100%;
-        left: 0px;
-        /* filter: alpha( opacity=75 ); */
+      left: 0px;
+   /* filter: alpha( opacity=75 ); */
         opacity: 0.75;
         position: absolute;
         top: 0px;
         width: 100%;
-        z-index: 99999;
+    z-index: 99999;
     }
 
 </style>


### PR DESCRIPTION
Links on rows with light blue background (#AED6F1) were disappearing when hovered due to the global a:hover color being set to lightblue, which blended with the row background.

Changes:

Added scoped CSS rules in _egrants_showDocsDownload.cshtml for DataTable links
Links now display as darkblue by default
Hover state changes to black with underline for clear visibility
Fix applies to both white and light blue alternating row backgrounds
Fixes issue where users couldn't see document links when hovering on odd-numbered rows in the Audit File Download grid.