### PR TITLE
Refactor: Rename by_appl parameter from applId to appl_id

### DIFF
--- a/source-aspnet/eGrants.Tests/Integration/EgrantsControllerTests.cs
+++ b/source-aspnet/eGrants.Tests/Integration/EgrantsControllerTests.cs
@@ -392,8 +392,8 @@ namespace eGrants.Tests.Integration
 
             var controller = CreateController(context, session);
             var result = await controller.by_appl(
-                    applId: 4040100
-                ) as ViewResult;
+                appl_id:4040100
+            ) as ViewResult;
 
             // Verifies the view and ensures model is correctly typed and populated
             Assert.NotNull(result);
@@ -412,10 +412,10 @@ namespace eGrants.Tests.Integration
 
             var controller = CreateController(context, session);
             var result = await controller.by_appl(
-                    applId: 4001001,
-                    mode: "full",
-                    str: "testString"
-                ) as ViewResult;
+                appl_id:4001001,
+                mode: "full",
+                str: "testString"
+            ) as ViewResult;
 
             // Verifies fallback behavior still returns view and model
             Assert.NotNull(result);

--- a/source-aspnet/eGrants/Controllers/Egrants/EgrantsController.cs
+++ b/source-aspnet/eGrants/Controllers/Egrants/EgrantsController.cs
@@ -436,13 +436,13 @@ namespace eGrants.Controllers.Egrants
         /// The <see cref="ActionResult"/>.
         /// </returns>
         public async Task<IActionResult> by_appl(
-            int applId = 0,
+            int appl_id = 0,
             string mode = null,
             string str = null)
         {
             var sessionInfo = _sessionInfoService.GetSessionInfo(HttpContext.Session);
 
-            eGrantsSearchViewModel eGrantsSearchViewModelList = await _eGrantsService.GetEgrantsByApplAsync(applId, mode, str, sessionInfo);
+            eGrantsSearchViewModel eGrantsSearchViewModelList = await _eGrantsService.GetEgrantsByApplAsync(appl_id, mode, str, sessionInfo);
 
             eGrantsSearchViewModelList.ICList = await _commonService.LoadAdminCodes();
 

--- a/source-aspnet/eGrants/Views/Admin/GrantDestructed.cshtml
+++ b/source-aspnet/eGrants/Views/Admin/GrantDestructed.cshtml
@@ -22,7 +22,7 @@
     }
 
     function show_appl(appl_id) {
-        var url = "@Url.Action("by_appl", "Egrants")?applId=" + appl_id;
+        var url = "@Url.Action("by_appl", "Egrants")?appl_id=" + appl_id;
         window.open(url, top);
     }
 </script>

--- a/source-aspnet/eGrants/Views/FundingFiles/FundingApplEdit.cshtml
+++ b/source-aspnet/eGrants/Views/FundingFiles/FundingApplEdit.cshtml
@@ -25,7 +25,7 @@
     }
 
     function by_appl(appl_id) {
-        var url = "@Url.Action("by_appl", "Egrants")?applId=" + appl_id;
+        var url = "@Url.Action("by_appl", "Egrants")?appl_id=" + appl_id;
         window.document.location.href = url;
     }
 

--- a/source-aspnet/eGrants/Views/Shared/_egrants_showSearchForm.cshtml
+++ b/source-aspnet/eGrants/Views/Shared/_egrants_showSearchForm.cshtml
@@ -177,7 +177,7 @@
         if (appl_id == -1) {
             return false;
         }
-        var url = "@Url.Action("by_appl", "Egrants")?applId=" + appl_id;
+        var url = "@Url.Action("by_appl", "Egrants")?appl_id=" + appl_id;
         window.document.location.href = url;
         //by_appl(appl_id);
     }

--- a/source-aspnet/eGrants/wwwroot/js/EgrantsIndex.js
+++ b/source-aspnet/eGrants/wwwroot/js/EgrantsIndex.js
@@ -146,7 +146,7 @@ function by_appl(appl_id) {
         mode = "";
     }
 
-    var url = 'by_appl?applId=' + appl_id + '&mode=' + mode;
+    var url = 'by_appl?appl_id=' + appl_id + '&mode=' + mode;
     window.document.location.href = url;
 }
 


### PR DESCRIPTION
- Updated the by_appl method in EgrantsController to use appl_id instead of applId for consistency with other parameter naming.
- Updated all internal references and logic in the method to use appl_id.
- Updated all test cases and any JavaScript calls (e.g., in EgrantsIndex.js) to use appl_id as the parameter name.