### PR TITLE
Merge from Dev to Test branch

### DIFF
--- a/source-aspnet/eGrants/Controllers/Egrants/EgrantsDocController.cs
+++ b/source-aspnet/eGrants/Controllers/Egrants/EgrantsDocController.cs
@@ -1639,5 +1639,19 @@ namespace eGrants.Controllers.Egrants
 
             return this.View("~/Views/Egrants/CloseoutNotif.cshtml");
         }
+
+        /// <summary>
+        /// Upload document by drag-and-drop (fixes404 and matches other upload actions).
+        /// </summary>
+        /// <param name="dropedfile">The file to upload.</param>
+        /// <param name="doc_id">The document ID.</param>
+        /// <returns>JSON result with upload status.</returns>
+        [HttpPost]
+        [ResponseCache(Duration =0, Location = ResponseCacheLocation.None, NoStore = true)]
+        public async Task<IActionResult> doc_upload_by_ddrop(IFormFile dropedfile, int doc_id)
+        {
+            var result = await _documentService.DocUploadByFileAsync(dropedfile, doc_id, sessionInfo);
+            return Json(new { url = result.Url, message = result.Message });
+        }
     }
 }

--- a/source-aspnet/eGrants/Services/DocumentService.cs
+++ b/source-aspnet/eGrants/Services/DocumentService.cs
@@ -531,7 +531,12 @@ string admin_code,
 
                     docName = Convert.ToString(docId) + fileExtension;
 
+#if DEBUG
+                    var fileFolder = "C:\\PdfFileOutput\\";
+#else
                     var fileFolder = @"\\" + sessionInfo.WebGrantUrl + "\\egrants\\funded\\nci\\modify\\";
+#endif
+
                     var filePath = Path.Combine(fileFolder, docName);
 
                     using (var stream = new FileStream(filePath, FileMode.Create))

--- a/source-aspnet/eGrants/Views/eGrants/EgrantsDocUpload.cshtml
+++ b/source-aspnet/eGrants/Views/eGrants/EgrantsDocUpload.cshtml
@@ -176,7 +176,7 @@
         var frmdata = new FormData();
 
         frmdata.append('dropedfile', dropedfile);
-        frmdata.append('docId', document_id);
+        frmdata.append('doc_id', document_id);
         docupload(frmdata, "/EgrantsDoc/doc_upload_by_ddrop");
 
         clear_all("by_dd");


### PR DESCRIPTION
Added doc_upload_by_ddrop method to correctly handle the drag and drop and upload of replacement documents

Updated DocumentService to use C:\PdfFileOutput\ for drag-and-drop and upload file operations when running locally (DEBUG)
Ensures production continues to use the network path

Affects only DocCreateByDdropAsync and DocUploadByDdropAsync methods