### PR TITLE
Fix incorrect session accessor causing 404 on supplement document links

### DIFF
--- a/source-aspnet/eGrants/Views/eGrants/Supplement.cshtml
+++ b/source-aspnet/eGrants/Views/eGrants/Supplement.cshtml
@@ -168,7 +168,7 @@
     <form name="frmGetInfo">
         <input type="text" hidden name="grant_id" value="@Model.GrantID" />
             <input type="text" hidden name="status" value="@Model.Status" />
-            <input type="text" hidden id="hidImageServer" name="ImageServer" value="@Convert.ToString(ViewContext.HttpContext.Session.GetInt32("ImageServerUrl"))" />
+            <input type="text" hidden id="hidImageServer" name="ImageServer" value="@Convert.ToString(ViewContext.HttpContext.Session.GetString("ImageServerUrl"))" />
         </form>
 
     <div id="caption" style="padding:  10px 20px;">

--- a/source-aspnet/eGrants/Views/eGrants/_Modal_Supplement.cshtml
+++ b/source-aspnet/eGrants/Views/eGrants/_Modal_Supplement.cshtml
@@ -176,7 +176,7 @@
     <form name="frmGetInfo">
         <input type="text" hidden name="grant_id" value="@Model.GrantID" />
         <input type="text" hidden name="status" value="@Model.Status" />
-        <input type="text" hidden id="hidImageServer" name="ImageServer" value="@Convert.ToString(ViewContext.HttpContext.Session.GetInt32("ImageServerUrl"))" />  
+        <input type="text" hidden id="hidImageServer" name="ImageServer" value="@ViewContext.HttpContext.Session.GetString("ImageServerUrl")" />  
     </form>
 
     <div id="caption" style="padding:  10px 20px;">
@@ -317,6 +317,3 @@
 </div><!--end main-->
 @*</body>
 </html>*@
-
-
-


### PR DESCRIPTION
Changed ImageServerUrl session retrieval from GetInt32 to GetString in supplement modal views. The incorrect method was causing the image server base URL to be replaced with a numeric value, resulting in malformed document URLs.

Before: /EgrantsDoc/1752462448data/funded2/nci/main/as26597821809.txt (404)
After:  /data/funded2/nci/main/as26597821809.txt (correct)

Files modified:
- eGrants\Views\eGrants\_Modal_Supplement.cshtml
- eGrants\Views\eGrants\Supplement.cshtml